### PR TITLE
Link al RSS de artículos en el menú

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -21,3 +21,9 @@ theme=  'ananke'
     name = 'Membresias'
     pageRef = '/membresias'
     weight = 30
+
+[[menu.main]]
+    name = 'RSS'
+    url = '/posts/index.xml'
+    identifier = "rss"
+    weight = 40


### PR DESCRIPTION
Agrega el link al RSS de artículos al final (a la derecha) del menú principal.